### PR TITLE
Move jwt.verify to try {} block

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -2,17 +2,17 @@ const jwt = require('jsonwebtoken')
 const User = require('../models/User')
 
 const auth = async(req, res, next) => {
-		const token = req.header('Authorization').replace('Bearer ', '')
-		
+    const token = req.header('Authorization').replace('Bearer ', '')
+
     try {
-				const data = jwt.verify(token, process.env.JWT_KEY)
+        const data = jwt.verify(token, process.env.JWT_KEY)
         const user = await User.findOne({ _id: data._id, 'tokens.token': token })
 
-				if (!user) {
+        if (!user) {
             throw new Error()
         }
 
-				req.user = user
+        req.user = user
         req.token = token
         next()
     } catch (error) {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -2,19 +2,22 @@ const jwt = require('jsonwebtoken')
 const User = require('../models/User')
 
 const auth = async(req, res, next) => {
-    const token = req.header('Authorization').replace('Bearer ', '')
-    const data = jwt.verify(token, process.env.JWT_KEY)
+		const token = req.header('Authorization').replace('Bearer ', '')
+		
     try {
+				const data = jwt.verify(token, process.env.JWT_KEY)
         const user = await User.findOne({ _id: data._id, 'tokens.token': token })
-        if (!user) {
+
+				if (!user) {
             throw new Error()
         }
-        req.user = user
+
+				req.user = user
         req.token = token
         next()
     } catch (error) {
         res.status(401).send({ error: 'Not authorized to access this resource' })
     }
-
 }
+
 module.exports = auth


### PR DESCRIPTION
In case empty or malformed token we have an error like
`JWT must be provided or JWT malformed`.

Here I move `jwt.verify()` to `try {}` block.
In this case we can see
`Not authorized to access this resource` instead of
crash in console and user can relogin now.

See this issue #3 